### PR TITLE
Hash Function Address Scheme

### DIFF
--- a/include/address.hpp
+++ b/include/address.hpp
@@ -187,4 +187,23 @@ struct fors_tree_t : adrs_t
   }
 };
 
+// Structure of FORS Tree Root Compression Address
+struct fors_roots_t : adrs_t
+{
+  // Returns 1 -word wide keypair address
+  uint32_t get_keypair_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 20);
+  }
+
+  // Sets 1 -word wide key pair address
+  void set_keypair_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 20);
+  }
+
+  // Zeros last two words of ADRS structure
+  void set_padding() { std::memset(data + 24, 0, sizeof(uint32_t) * 2); }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -206,4 +206,38 @@ struct fors_roots_t : adrs_t
   void set_padding() { std::memset(data + 24, 0, sizeof(uint32_t) * 2); }
 };
 
+// Structure of WOTS+ Key Generation Address
+struct wots_prf_t : adrs_t
+{
+  // Returns 1 -word wide keypair address
+  uint32_t get_keypair_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 20);
+  }
+
+  // Set 1 -word wide key pair address
+  void set_keypair_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 20);
+  }
+
+  // Returns 1 -word wide chain address
+  uint32_t get_chain_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 24);
+  }
+
+  // Set 1 -word wide chain address
+  void set_chain_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 24);
+  }
+
+  // Returns 1 -word wide hash address, which is always set to 0
+  uint32_t get_hash_address() { return 0u; }
+
+  // Zeros 1 -word wide hash address
+  void set_hash_address() { std::memset(data + 28, 0, sizeof(uint32_t)); }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -240,4 +240,35 @@ struct wots_prf_t : adrs_t
   void set_hash_address() { std::memset(data + 28, 0, sizeof(uint32_t)); }
 };
 
+// Structure of FORS Key Generation Address
+struct fors_prf_t : adrs_t
+{
+  // Returns 1 -word wide keypair address
+  uint32_t get_keypair_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 20);
+  }
+
+  // Sets 1 -word wide key pair address
+  void set_keypair_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 20);
+  }
+
+  // Returns 1 -word wide tree height
+  uint32_t get_tree_height() { return 0u; }
+
+  // Zeros 1 -word wide tree height
+  void set_tree_height() { std::memset(data + 24, 0, sizeof(uint32_t)); }
+
+  // Returns 1 -word wide tree index
+  uint32_t get_tree_index() { return sphincs_utils::from_be_bytes(data + 28); }
+
+  // Sets 1 -word wide tree index
+  void set_tree_index(const uint32_t idx)
+  {
+    sphincs_utils::to_be_bytes(idx, data + 28);
+  }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -109,4 +109,23 @@ struct wots_hash_t : adrs_t
   }
 };
 
+// Structure of WOTS+ Public Key Compression Address
+struct wots_pk_t : adrs_t
+{
+  // Returns 1 -word wide keypair address
+  uint32_t get_keypair_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 20);
+  }
+
+  // Set 1 -word wide key pair address
+  void set_keypair_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 20);
+  }
+
+  // Zeros last two words of ADRS structure
+  void set_padding() { std::memset(data + 24, 0, sizeof(uint32_t) * 2); }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -128,4 +128,29 @@ struct wots_pk_t : adrs_t
   void set_padding() { std::memset(data + 24, 0, sizeof(uint32_t) * 2); }
 };
 
+// Structure of Main Hash Tree Address
+struct tree_t : adrs_t
+{
+  // Zeros 1 -word wide padding
+  void set_padding() { std::memset(data + 20, 0, sizeof(uint32_t)); }
+
+  // Returns 1 -word wide tree height
+  uint32_t get_tree_height() { return sphincs_utils::from_be_bytes(data + 24); }
+
+  // Sets 1 -word wide tree height
+  void set_tree_height(const uint32_t height)
+  {
+    sphincs_utils::to_be_bytes(height, data + 24);
+  }
+
+  // Returns 1 -word wide tree index
+  uint32_t get_tree_index() { return sphincs_utils::from_be_bytes(data + 28); }
+
+  // Sets 1 -word wide tree index
+  void set_tree_index(const uint32_t idx)
+  {
+    sphincs_utils::to_be_bytes(idx, data + 28);
+  }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -153,4 +153,38 @@ struct tree_t : adrs_t
   }
 };
 
+// Structure of FORS Tree Address
+struct fors_tree_t : adrs_t
+{
+  // Returns 1 -word wide keypair address
+  uint32_t get_keypair_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 20);
+  }
+
+  // Sets 1 -word wide key pair address
+  void set_keypair_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 20);
+  }
+
+  // Returns 1 -word wide tree height
+  uint32_t get_tree_height() { return sphincs_utils::from_be_bytes(data + 24); }
+
+  // Sets 1 -word wide tree height
+  void set_tree_height(const uint32_t height)
+  {
+    sphincs_utils::to_be_bytes(height, data + 24);
+  }
+
+  // Returns 1 -word wide tree index
+  uint32_t get_tree_index() { return sphincs_utils::from_be_bytes(data + 28); }
+
+  // Sets 1 -word wide tree index
+  void set_tree_index(const uint32_t idx)
+  {
+    sphincs_utils::to_be_bytes(idx, data + 28);
+  }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -27,10 +27,24 @@ struct adrs_t
 {
   uint8_t data[32]{};
 
+  // Returns 1 -word wide layer address
+  uint32_t get_layer_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 0);
+  }
+
   // Only sets 1 -word wide layer address
   void set_layer_address(const uint32_t address)
   {
     sphincs_utils::to_be_bytes(address, data + 0);
+  }
+
+  // Returns 3 -word wide tree address
+  std::array<uint32_t, 3> get_tree_address()
+  {
+    return { sphincs_utils::from_be_bytes(data + 4),
+             sphincs_utils::from_be_bytes(data + 8),
+             sphincs_utils::from_be_bytes(data + 12) };
   }
 
   // Only sets 3 -word wide tree address
@@ -39,6 +53,12 @@ struct adrs_t
     sphincs_utils::to_be_bytes(address[0], data + 4);
     sphincs_utils::to_be_bytes(address[1], data + 8);
     sphincs_utils::to_be_bytes(address[2], data + 12);
+  }
+
+  // Returns 1 -word wide address type
+  type_t get_type()
+  {
+    return static_cast<type_t>(sphincs_utils::from_be_bytes(data + 16));
   }
 
   // Sets 1 -word wide address type, along with that zeros subsequent 3 -words.

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -69,4 +69,44 @@ struct adrs_t
   }
 };
 
+// Structure of WOTS+ Hash Address
+struct wots_hash_t : adrs_t
+{
+  // Returns 1 -word wide keypair address
+  uint32_t get_keypair_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 20);
+  }
+
+  // Set 1 -word wide key pair address
+  void set_keypair_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 20);
+  }
+
+  // Returns 1 -word wide chain address
+  uint32_t get_chain_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 24);
+  }
+
+  // Set 1 -word wide chain address
+  void set_chain_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 24);
+  }
+
+  // Returns 1 -word wide hash address
+  uint32_t get_hash_address()
+  {
+    return sphincs_utils::from_be_bytes(data + 28);
+  }
+
+  // Set 1 -word wide hash address
+  void set_hash_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 28);
+  }
+};
+
 }

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include "utils.hpp"
+#include <array>
+#include <cstring>
+
+// Hash function address scheme for SPHINCS+
+namespace sphincs_adrs {
+
+// Allowed SPHINCS+ address types
+//
+// See bottom of page 13 of specification
+// https://sphincs.org/data/sphincs+-r3.1-specification.pdf
+enum class type_t : uint32_t
+{
+  WOTS_HASH = 0,
+  WOTS_PK = 1,
+  TREE = 2,
+  FORS_TREE = 3,
+  FORS_ROOTS = 4,
+  WOTS_PRF = 5,
+  FORS_PRF = 6
+};
+
+// Common structure of SPHINCS+ ADRS ( 32 -bytes wide ), with each word being
+// 4 -bytes.
+struct adrs_t
+{
+  uint8_t data[32]{};
+
+  // Only sets 1 -word wide layer address
+  void set_layer_address(const uint32_t address)
+  {
+    sphincs_utils::to_be_bytes(address, data + 0);
+  }
+
+  // Only sets 3 -word wide tree address
+  void set_tree_address(const std::array<uint32_t, 3> address)
+  {
+    sphincs_utils::to_be_bytes(address[0], data + 4);
+    sphincs_utils::to_be_bytes(address[1], data + 8);
+    sphincs_utils::to_be_bytes(address[2], data + 12);
+  }
+
+  // Sets 1 -word wide address type, along with that zeros subsequent 3 -words.
+  void set_type(const type_t type)
+  {
+    sphincs_utils::to_be_bytes(static_cast<uint32_t>(type), data + 16);
+    std::memset(data + 20, 0, sizeof(uint32_t) * 3);
+  }
+};
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+// Utility functions for SPHINCS+
+namespace sphincs_utils {
+
+// Given a 32 -bit word, this routine extracts out each byte from that word and
+// places them in a big endian byte array.
+inline static void
+to_be_bytes(const uint32_t word, uint8_t* const bytes)
+{
+  bytes[0] = static_cast<uint8_t>(word >> 24);
+  bytes[1] = static_cast<uint8_t>(word >> 16);
+  bytes[2] = static_cast<uint8_t>(word >> 8);
+  bytes[3] = static_cast<uint8_t>(word >> 0);
+}
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -16,4 +16,15 @@ to_be_bytes(const uint32_t word, uint8_t* const bytes)
   bytes[3] = static_cast<uint8_t>(word >> 0);
 }
 
+// Given a byte array of length 4, this routine converts it to a big endian 32
+// -bit word.
+inline static uint32_t
+from_be_bytes(const uint8_t* const bytes)
+{
+  return (static_cast<uint32_t>(bytes[0]) << 24) |
+         (static_cast<uint32_t>(bytes[1]) << 16) |
+         (static_cast<uint32_t>(bytes[2]) << 8) |
+         (static_cast<uint32_t>(bytes[3]) << 0);
+}
+
 }


### PR DESCRIPTION
Implemented structure of ADRS for

- [x] WOTS+ hash address
- [x] WOTS+ public key compression address
- [x] Main hash tree address
- [x] FORS tree address
- [x] FORS tree root compression address
- [x] WOTS+ key generation address
- [x] FORS key generation address 

> **Note**
> See section 2.7.3 of SPHINCS+ specification https://sphincs.org/data/sphincs+-r3.1-specification.pdf