### PR TITLE
WOTS+ : One-Time Signature (OTS) scheme used in SPHINCS+

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -1,0 +1,25 @@
+name: Test SPHINCS+ using CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Compiler
+      run: |
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+    - name: Fetch Dependency
+      run: git submodule update --init
+    - name: Execute Tests
+      run: make
+    - name: Cleanup
+      run: make clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+CXX = g++
+CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
+OPTFLAGS = -O3 -march=native
+IFLAGS = -I ./include
+DEP_IFLAGS = -I ./sha3/include
+
+all: testing
+
+test/a.out: test/main.cpp include/*.hpp sha3/include/*.hpp
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -o $@
+
+testing: test/a.out
+	./$<
+
+clean:
+	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
+
+format:
+	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla

--- a/include/address.hpp
+++ b/include/address.hpp
@@ -27,6 +27,9 @@ struct adrs_t
 {
   uint8_t data[32]{};
 
+  adrs_t() {}
+  adrs_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide layer address
   uint32_t get_layer_address()
   {
@@ -72,6 +75,9 @@ struct adrs_t
 // Structure of WOTS+ Hash Address
 struct wots_hash_t : adrs_t
 {
+  wots_hash_t() {}
+  wots_hash_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide keypair address
   uint32_t get_keypair_address()
   {
@@ -112,6 +118,9 @@ struct wots_hash_t : adrs_t
 // Structure of WOTS+ Public Key Compression Address
 struct wots_pk_t : adrs_t
 {
+  wots_pk_t() {}
+  wots_pk_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide keypair address
   uint32_t get_keypair_address()
   {
@@ -131,6 +140,9 @@ struct wots_pk_t : adrs_t
 // Structure of Main Hash Tree Address
 struct tree_t : adrs_t
 {
+  tree_t() {}
+  tree_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Zeros 1 -word wide padding
   void set_padding() { std::memset(data + 20, 0, sizeof(uint32_t)); }
 
@@ -156,6 +168,9 @@ struct tree_t : adrs_t
 // Structure of FORS Tree Address
 struct fors_tree_t : adrs_t
 {
+  fors_tree_t() {}
+  fors_tree_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide keypair address
   uint32_t get_keypair_address()
   {
@@ -190,6 +205,9 @@ struct fors_tree_t : adrs_t
 // Structure of FORS Tree Root Compression Address
 struct fors_roots_t : adrs_t
 {
+  fors_roots_t() {}
+  fors_roots_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide keypair address
   uint32_t get_keypair_address()
   {
@@ -209,6 +227,9 @@ struct fors_roots_t : adrs_t
 // Structure of WOTS+ Key Generation Address
 struct wots_prf_t : adrs_t
 {
+  wots_prf_t() {}
+  wots_prf_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide keypair address
   uint32_t get_keypair_address()
   {
@@ -243,6 +264,9 @@ struct wots_prf_t : adrs_t
 // Structure of FORS Key Generation Address
 struct fors_prf_t : adrs_t
 {
+  fors_prf_t() {}
+  fors_prf_t(const adrs_t& adrs) { std::memcpy(data, adrs.data, 32); }
+
   // Returns 1 -word wide keypair address
   uint32_t get_keypair_address()
   {

--- a/include/test/test_sphincs.hpp
+++ b/include/test/test_sphincs.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "test_wots.hpp"

--- a/include/test/test_wots.hpp
+++ b/include/test/test_wots.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include "wots.hpp"
+#include <cassert>
+
+// Test functional correctness of SPHINCS+
+namespace test_sphincs {
+
+// Test correctness of WOTS+ implementation, in standalone mode, using
+//
+// - Public key generation
+// - Signing using private key
+// - Verifying signature by recovering public key from message and signature
+//
+// Note, WOTS+ is the One-Time Signature scheme that is used in SPHINCS+, though
+// its API is not fit for standalone usage, here random data filled WOTS+ hash
+// address is used for ensuring correctness - which should work correctly.
+template<const size_t n, const size_t w, const sphincs_hashing::variant v>
+inline static void
+test_wots()
+{
+  constexpr size_t len = sphincs_utils::compute_wots_len<n, w>();
+
+  // Input
+  uint8_t* sk_seed = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * n));
+  uint8_t* pk_seed = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * n));
+  sphincs_adrs::wots_hash_t adrs{};
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * n));
+
+  // Output
+  uint8_t* pkey0 = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * n));
+  uint8_t* pkey1 = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * n));
+  uint8_t* sig = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * n * len));
+
+  sphincs_utils::random_data<uint8_t>(sk_seed, n);
+  sphincs_utils::random_data<uint8_t>(pk_seed, n);
+  sphincs_utils::random_data<uint8_t>(adrs.data, 32);
+  sphincs_utils::random_data<uint8_t>(msg, n);
+
+  sphincs_wots::pkgen<n, w, v>(sk_seed, pk_seed, adrs, pkey0);
+  sphincs_wots::sign<n, w, v>(msg, sk_seed, pk_seed, adrs, sig);
+  sphincs_wots::pk_from_sig<n, w, v>(sig, msg, pk_seed, adrs, pkey1);
+
+  bool flg = false;
+  for (size_t i = 0; i < n; i++) {
+    flg |= static_cast<bool>(pkey0[i] ^ pkey1[i]);
+  }
+
+  std::free(sk_seed);
+  std::free(pk_seed);
+  std::free(pkey0);
+  std::free(pkey1);
+  std::free(msg);
+  std::free(sig);
+
+  assert(!flg);
+}
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -5,6 +5,16 @@
 // Utility functions for SPHINCS+
 namespace sphincs_utils {
 
+// Compile-time check to ensure that `w` parameter takes only allowed values.
+//
+// See Winternitz Parameter point in section 3.1 of
+// https://sphincs.org/data/sphincs+-r3.1-specification.pdf
+inline static consteval bool
+check_w(const size_t w)
+{
+  return (w == 4) || (w == 16) || (w == 256);
+}
+
 // Given a 32 -bit word, this routine extracts out each byte from that word and
 // places them in a big endian byte array.
 inline static void

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -100,9 +100,9 @@ from_be_bytes(const uint8_t* const bytes)
 //
 // See section 2.5 of SPHINCS+ specification
 // https://sphincs.org/data/sphincs+-r3.1-specification.pdf
-template<const size_t w>
+template<const size_t w, const size_t ilen, const size_t olen>
 inline static constexpr bool
-check_olen(const size_t ilen, const size_t olen)
+check_olen()
 {
   constexpr size_t lgw = log2<w>();
   constexpr size_t max = (8 * ilen) / lgw;
@@ -145,11 +145,10 @@ to_byte(const T x)
 //
 // See algorithm 1 in section 2.5 of SPHINCS+ specification
 // https://sphincs.org/data/sphincs+-r3.1-specification.pdf
-template<const size_t w, const size_t olen>
+template<const size_t w, const size_t ilen, const size_t olen>
 inline static void
-base_w(const uint8_t* const __restrict in,
-       const size_t ilen,
-       uint8_t* const __restrict out)
+base_w(const uint8_t* const __restrict in, uint8_t* const __restrict out)
+  requires(check_olen<w, ilen, olen>())
 {
   constexpr size_t lgw = log2<w>();
   constexpr uint8_t mask = w - 1;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
+#include <random>
 #include <sstream>
 #include <type_traits>
 
@@ -185,6 +186,21 @@ to_hex(const uint8_t* const bytes, const size_t len)
   }
 
   return ss.str();
+}
+
+// Generates N -many random values of type T | N >= 0
+template<typename T>
+static inline void
+random_data(T* const data, const size_t len)
+  requires(std::is_unsigned_v<T>)
+{
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+  std::uniform_int_distribution<T> dis;
+
+  for (size_t i = 0; i < len; i++) {
+    data[i] = dis(gen);
+  }
 }
 
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
+#include <sstream>
 
 // Utility functions for SPHINCS+
 namespace sphincs_utils {
@@ -35,6 +37,21 @@ from_be_bytes(const uint8_t* const bytes)
          (static_cast<uint32_t>(bytes[1]) << 16) |
          (static_cast<uint32_t>(bytes[2]) << 8) |
          (static_cast<uint32_t>(bytes[3]) << 0);
+}
+
+// Given a bytearray of length N, this function converts it to human readable
+// hex string of length N << 1 | N >= 0
+static inline const std::string
+to_hex(const uint8_t* const bytes, const size_t len)
+{
+  std::stringstream ss;
+  ss << std::hex;
+
+  for (size_t i = 0; i < len; i++) {
+    ss << std::setw(2) << std::setfill('0') << static_cast<uint32_t>(bytes[i]);
+  }
+
+  return ss.str();
 }
 
 }

--- a/include/wots.hpp
+++ b/include/wots.hpp
@@ -110,7 +110,7 @@ sign(const uint8_t* const __restrict msg,     // n -bytes message to sign
   uint32_t csum = 0;
   uint8_t tmp[len]{};
 
-  sphincs_utils::base_w<w, len1>(msg, n, tmp);
+  sphincs_utils::base_w<w, n, len1>(msg, tmp);
 
   for (size_t i = 0; i < len1; i++) {
     csum += static_cast<uint32_t>(w - 1ul) - static_cast<uint32_t>(tmp[i]);
@@ -125,7 +125,7 @@ sign(const uint8_t* const __restrict msg,     // n -bytes message to sign
   constexpr size_t len_2_bytes = t1 >> 3; // = ceil(t0 / 8)
 
   const auto bytes = sphincs_utils::to_byte<uint32_t, len_2_bytes>(csum);
-  sphincs_utils::base_w<w, len2>(bytes.data(), len_2_bytes, tmp + len1);
+  sphincs_utils::base_w<w, len_2_bytes, len2>(bytes.data(), tmp + len1);
 
   sphincs_adrs::wots_prf_t sk_adrs{ adrs };
 
@@ -175,7 +175,7 @@ pk_from_sig(
   uint32_t csum = 0;
   uint8_t tmp0[len]{};
 
-  sphincs_utils::base_w<w, len1>(msg, n, tmp0);
+  sphincs_utils::base_w<w, n, len1>(msg, tmp0);
 
   for (size_t i = 0; i < len1; i++) {
     csum += static_cast<uint32_t>(w - 1ul) - static_cast<uint32_t>(tmp0[i]);
@@ -190,7 +190,7 @@ pk_from_sig(
   constexpr size_t len_2_bytes = t1 >> 3; // = ceil(t0 / 8)
 
   const auto bytes = sphincs_utils::to_byte<uint32_t, len_2_bytes>(csum);
-  sphincs_utils::base_w<w, len2>(bytes.data(), len_2_bytes, tmp0 + len1);
+  sphincs_utils::base_w<w, len_2_bytes, len2>(bytes.data(), tmp0 + len1);
 
   uint8_t tmp1[n * len]{};
 

--- a/include/wots.hpp
+++ b/include/wots.hpp
@@ -108,12 +108,12 @@ sign(const uint8_t* const __restrict msg,     // n -bytes message to sign
   constexpr size_t len = len1 + len2;
 
   uint32_t csum = 0;
-  uint8_t msg_[len]{};
+  uint8_t tmp[len]{};
 
-  sphincs_utils::base_w<w, len1>(msg, n, msg_);
+  sphincs_utils::base_w<w, len1>(msg, n, tmp);
 
   for (size_t i = 0; i < len1; i++) {
-    csum += static_cast<uint32_t>(w - 1ul) - static_cast<uint32_t>(msg_[i]);
+    csum += static_cast<uint32_t>(w - 1ul) - static_cast<uint32_t>(tmp[i]);
   }
 
   if constexpr ((lgw & 7ul) != 0) {
@@ -125,7 +125,7 @@ sign(const uint8_t* const __restrict msg,     // n -bytes message to sign
   constexpr size_t len_2_bytes = t1 >> 3; // = ceil(t0 / 8)
 
   const auto bytes = sphincs_utils::to_byte<uint32_t, len_2_bytes>(csum);
-  sphincs_utils::base_w<w, len2>(bytes.data(), len_2_bytes, msg_ + len1);
+  sphincs_utils::base_w<w, len2>(bytes.data(), len_2_bytes, tmp + len1);
 
   sphincs_adrs::wots_prf_t sk_adrs{ adrs };
 
@@ -145,9 +145,70 @@ sign(const uint8_t* const __restrict msg,     // n -bytes message to sign
     adrs.set_chain_address(i);
     adrs.set_hash_address(0);
 
-    const uint32_t steps = static_cast<uint32_t>(msg[i]);
+    const uint32_t steps = static_cast<uint32_t>(tmp[i]);
     chain<n, w, v>(sk, 0u, steps, adrs, pk_seed, sig + off);
   }
+}
+
+// Computes n -bytes WOTS+ compressed public key from n -bytes message and
+// n * len -bytes signature, when n -bytes public key seed and 32 -bytes WOTS+
+// hash address is also provided, using algorithm 6, defined in section 3.6 of
+// SPHINCS+ specification
+// https://sphincs.org/data/sphincs+-r3.1-specification.pdf
+template<const size_t n, const size_t w, const sphincs_hashing::variant v>
+inline static void
+pk_from_sig(
+  const uint8_t* const __restrict sig, // n * len -bytes signature
+  const uint8_t* const __restrict msg, // n -bytes message ( which was signed )
+  const uint8_t* const __restrict pk_seed, // n -bytes public key seed
+  sphincs_adrs::wots_hash_t adrs,          // 32 -bytes WOTS+ hash address
+  uint8_t* const __restrict pkey           // n -bytes public key
+)
+{
+  constexpr size_t lgw = sphincs_utils::log2<w>();
+  constexpr size_t len1 = sphincs_utils::compute_wots_len1<n, w>();
+  constexpr size_t len2 = sphincs_utils::compute_wots_len2<n, w, len1>();
+  constexpr size_t len = len1 + len2;
+
+  sphincs_adrs::wots_pk_t pk_adrs{ adrs };
+
+  uint32_t csum = 0;
+  uint8_t tmp0[len]{};
+
+  sphincs_utils::base_w<w, len1>(msg, n, tmp0);
+
+  for (size_t i = 0; i < len1; i++) {
+    csum += static_cast<uint32_t>(w - 1ul) - static_cast<uint32_t>(tmp0[i]);
+  }
+
+  if constexpr ((lgw & 7ul) != 0) {
+    csum <<= (8ul - ((len2 * lgw) & 7ul));
+  }
+
+  constexpr size_t t0 = len2 * lgw;
+  constexpr size_t t1 = t0 + 7ul;
+  constexpr size_t len_2_bytes = t1 >> 3; // = ceil(t0 / 8)
+
+  const auto bytes = sphincs_utils::to_byte<uint32_t, len_2_bytes>(csum);
+  sphincs_utils::base_w<w, len2>(bytes.data(), len_2_bytes, tmp0 + len1);
+
+  uint8_t tmp1[n * len]{};
+
+  for (uint32_t i = 0; i < static_cast<uint32_t>(len); i++) {
+    const size_t off = static_cast<size_t>(i) * n;
+
+    adrs.set_chain_address(i);
+    adrs.set_hash_address(0);
+
+    const uint32_t sidx = static_cast<uint32_t>(tmp0[i]);
+    const uint32_t steps = static_cast<uint32_t>((w - 1) - tmp0[i]);
+    chain<n, w, v>(sig + off, sidx, steps, adrs, pk_seed, tmp1 + off);
+  }
+
+  pk_adrs.set_type(sphincs_adrs::type_t::WOTS_PK);
+  pk_adrs.set_keypair_address(adrs.get_keypair_address());
+
+  sphincs_hashing::t_l<n, len, v>(pk_seed, pk_adrs.data, tmp1, pkey);
 }
 
 }

--- a/include/wots.hpp
+++ b/include/wots.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "address.hpp"
+#include "hashing.hpp"
+
+// One-Time Signature scheme WOTS+, used in SPHINCS+
+namespace sphincs_wots {
+
+// Given a n -bytes input message, 4 -bytes wide starting index, 4 -bytes wide
+// step count, 32 -bytes WOTS+ hash address and n -bytes public seed, this
+// routine computes a n -bytes output, which is the result of iteratively
+// applying tweakable hash function `F` on input string `x` for `steps` time.
+//
+// See algorithm 2 in section 3.2 of SPHINCS+ specification
+// https://sphincs.org/data/sphincs+-r3.1-specification.pdf
+template<const size_t n, const size_t w, const sphincs_hashing::variant v>
+inline static void
+chain(const uint8_t* const __restrict x,       // n -bytes
+      const uint32_t s_idx,                    // starting index
+      const uint32_t steps,                    // # -of steps
+      sphincs_adrs::wots_hash_t adrs,          // 32 -bytes WOTS+ hash address
+      const uint8_t* const __restrict pk_seed, // n -bytes public key seed
+      uint8_t* const __restrict chained        // n -bytes output
+      )
+  requires(sphincs_utils::check_w(w))
+{
+  const uint32_t till = s_idx + steps;
+  const bool flg = static_cast<size_t>(till) > (w - 1ul);
+  if (flg) {
+    std::memset(chained, 0, n);
+    return;
+  }
+
+  std::memcpy(chained, x, n);
+  uint8_t tmp[n]{};
+
+  for (uint32_t i = s_idx; i < till; i++) {
+    adrs.set_hash_address(i);
+
+    sphincs_hashing::f<n, v>(pk_seed, adrs.data, chained, tmp);
+    std::memcpy(chained, tmp, n);
+  }
+}
+
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,16 @@
+#include "test/test_sphincs.hpp"
+#include <iostream>
+
+int
+main()
+{
+  test_sphincs::test_wots<16, 16, sphincs_hashing::variant::robust>();
+  test_sphincs::test_wots<16, 16, sphincs_hashing::variant::simple>();
+  test_sphincs::test_wots<24, 16, sphincs_hashing::variant::robust>();
+  test_sphincs::test_wots<24, 16, sphincs_hashing::variant::simple>();
+  test_sphincs::test_wots<32, 16, sphincs_hashing::variant::robust>();
+  test_sphincs::test_wots<32, 16, sphincs_hashing::variant::simple>();
+  std::cout << "[test] WOTS+ one-time signature\n";
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- [x] Chaining function
- [x] Generate compressed WOTS+ public key
- [x] Sign message using WOTS+
- [x] Generate compressed WOTS+ public key from message & signature 
- [x] Test correctness ( standalone mode should suffice for now )

> **Note**
> For understanding what standalone more mean, read section 3.6 of SPHINCS+ specification https://sphincs.org/data/sphincs+-r3.1-specification.pdf