### PR TITLE
Benchmark SPHINCS+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEP_IFLAGS = -I ./sha3/include
 
 all: testing
 
-test/a.out: test/main.cpp include/*.hpp sha3/include/*.hpp
+test/a.out: test/main.cpp include/*/*.hpp sha3/include/*.hpp
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -o $@
 
 testing: test/a.out
@@ -17,3 +17,11 @@ clean:
 
 format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
+
+bench/a.out: bench/main.cpp include/*/*.hpp sha3/include/*.hpp
+	# make sure you've google-benchmark globally installed;
+	# see https://github.com/google/benchmark/tree/2257fa4#installation
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -lbenchmark -o $@
+
+benchmark: bench/a.out
+	./$<

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,0 +1,65 @@
+#include "bench/bench_sphincs.hpp"
+
+using namespace sphincs_hashing;
+
+// SPHINCS+-128s-robust
+BENCHMARK(bench_sphincs::keygen<16, 63, 7, 16, variant::robust>);
+BENCHMARK(bench_sphincs::sign<16, 63, 7, 12, 14, 16, variant::robust>);
+BENCHMARK(bench_sphincs::verify<16, 63, 7, 12, 14, 16, variant::robust>);
+
+// SPHINCS+-128s-simple
+BENCHMARK(bench_sphincs::keygen<16, 63, 7, 16, variant::simple>);
+BENCHMARK(bench_sphincs::sign<16, 63, 7, 12, 14, 16, variant::simple>);
+BENCHMARK(bench_sphincs::verify<16, 63, 7, 12, 14, 16, variant::simple>);
+
+// SPHINCS+-128f-robust
+BENCHMARK(bench_sphincs::keygen<16, 66, 22, 16, variant::robust>);
+BENCHMARK(bench_sphincs::sign<16, 66, 22, 6, 33, 16, variant::robust>);
+BENCHMARK(bench_sphincs::verify<16, 66, 22, 6, 33, 16, variant::robust>);
+
+// SPHINCS+-128f-simple
+BENCHMARK(bench_sphincs::keygen<16, 66, 22, 16, variant::simple>);
+BENCHMARK(bench_sphincs::sign<16, 66, 22, 6, 33, 16, variant::simple>);
+BENCHMARK(bench_sphincs::verify<16, 66, 22, 6, 33, 16, variant::simple>);
+
+// SPHINCS+-192s-robust
+BENCHMARK(bench_sphincs::keygen<24, 63, 7, 16, variant::robust>);
+BENCHMARK(bench_sphincs::sign<24, 63, 7, 14, 17, 16, variant::robust>);
+BENCHMARK(bench_sphincs::verify<24, 63, 7, 14, 17, 16, variant::robust>);
+
+// SPHINCS+-192s-simple
+BENCHMARK(bench_sphincs::keygen<24, 63, 7, 16, variant::simple>);
+BENCHMARK(bench_sphincs::sign<24, 63, 7, 14, 17, 16, variant::simple>);
+BENCHMARK(bench_sphincs::verify<24, 63, 7, 14, 17, 16, variant::simple>);
+
+// SPHINCS+-192f-robust
+BENCHMARK(bench_sphincs::keygen<24, 66, 22, 16, variant::robust>);
+BENCHMARK(bench_sphincs::sign<24, 66, 22, 8, 33, 16, variant::robust>);
+BENCHMARK(bench_sphincs::verify<24, 66, 22, 8, 33, 16, variant::robust>);
+
+// SPHINCS+-192f-simple
+BENCHMARK(bench_sphincs::keygen<24, 66, 22, 16, variant::simple>);
+BENCHMARK(bench_sphincs::sign<24, 66, 22, 8, 33, 16, variant::simple>);
+BENCHMARK(bench_sphincs::verify<24, 66, 22, 8, 33, 16, variant::simple>);
+
+// SPHINCS+-256s-robust
+BENCHMARK(bench_sphincs::keygen<32, 64, 8, 16, variant::robust>);
+BENCHMARK(bench_sphincs::sign<32, 64, 8, 14, 22, 16, variant::robust>);
+BENCHMARK(bench_sphincs::verify<32, 64, 8, 14, 22, 16, variant::robust>);
+
+// SPHINCS+-256s-simple
+BENCHMARK(bench_sphincs::keygen<32, 64, 8, 16, variant::simple>);
+BENCHMARK(bench_sphincs::sign<32, 64, 8, 14, 22, 16, variant::simple>);
+BENCHMARK(bench_sphincs::verify<32, 64, 8, 14, 22, 16, variant::simple>);
+
+// SPHINCS+-256f-robust
+BENCHMARK(bench_sphincs::keygen<32, 68, 17, 16, variant::robust>);
+BENCHMARK(bench_sphincs::sign<32, 68, 17, 9, 35, 16, variant::robust>);
+BENCHMARK(bench_sphincs::verify<32, 68, 17, 9, 35, 16, variant::robust>);
+
+// SPHINCS+-256f-simple
+BENCHMARK(bench_sphincs::keygen<32, 68, 17, 16, variant::simple>);
+BENCHMARK(bench_sphincs::sign<32, 68, 17, 9, 35, 16, variant::simple>);
+BENCHMARK(bench_sphincs::verify<32, 68, 17, 9, 35, 16, variant::simple>);
+
+BENCHMARK_MAIN();

--- a/include/bench/bench_sphincs.hpp
+++ b/include/bench/bench_sphincs.hpp
@@ -33,4 +33,44 @@ keygen(benchmark::State& state)
   std::free(skey);
 }
 
+// Benchmark SPHINCS+ signing algorithm
+template<const size_t n,
+         const uint32_t h,
+         const uint32_t d,
+         const uint32_t a,
+         const uint32_t k,
+         const size_t w,
+         const sphincs_hashing::variant v,
+         const bool randomize = false>
+inline static void
+sign(benchmark::State& state)
+{
+  namespace utils = sphincs_utils;
+  constexpr size_t pklen = utils::get_sphincs_pkey_len<n>();
+  constexpr size_t sklen = utils::get_sphincs_skey_len<n>();
+  constexpr size_t siglen = utils::get_sphincs_sig_len<n, h, d, a, k, w>();
+  constexpr size_t mlen = 32;
+
+  uint8_t* pkey = static_cast<uint8_t*>(std::malloc(pklen));
+  uint8_t* skey = static_cast<uint8_t*>(std::malloc(sklen));
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* sig = static_cast<uint8_t*>(std::malloc(siglen));
+
+  sphincs::keygen<n, h, d, w, v>(skey, pkey);
+
+  for (auto _ : state) {
+    sphincs::sign<n, h, d, a, k, w, v, randomize>(msg, mlen, skey, sig);
+
+    benchmark::DoNotOptimize(msg);
+    benchmark::DoNotOptimize(skey);
+    benchmark::DoNotOptimize(sig);
+    benchmark::ClobberMemory();
+  }
+
+  std::free(pkey);
+  std::free(skey);
+  std::free(msg);
+  std::free(sig);
+}
+
 }

--- a/include/bench/bench_sphincs.hpp
+++ b/include/bench/bench_sphincs.hpp
@@ -29,6 +29,8 @@ keygen(benchmark::State& state)
     benchmark::ClobberMemory();
   }
 
+  state.SetItemsProcessed(state.iterations());
+
   std::free(pkey);
   std::free(skey);
 }
@@ -67,6 +69,8 @@ sign(benchmark::State& state)
     benchmark::ClobberMemory();
   }
 
+  state.SetItemsProcessed(state.iterations());
+
   std::free(pkey);
   std::free(skey);
   std::free(msg);
@@ -80,7 +84,8 @@ template<const size_t n,
          const uint32_t a,
          const uint32_t k,
          const size_t w,
-         const sphincs_hashing::variant v>
+         const sphincs_hashing::variant v,
+         const bool randomize = false>
 inline static void
 verify(benchmark::State& state)
 {
@@ -107,6 +112,8 @@ verify(benchmark::State& state)
     benchmark::DoNotOptimize(pkey);
     benchmark::ClobberMemory();
   }
+
+  state.SetItemsProcessed(state.iterations());
 
   std::free(pkey);
   std::free(skey);

--- a/include/bench/bench_sphincs.hpp
+++ b/include/bench/bench_sphincs.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include "sphincs.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark SPHINCS+ Routines
+namespace bench_sphincs {
+
+// Benchmark SPHINCS+ keypair generation
+template<const size_t n,
+         const uint32_t h,
+         const uint32_t d,
+         const size_t w,
+         const sphincs_hashing::variant v>
+inline static void
+keygen(benchmark::State& state)
+{
+  namespace utils = sphincs_utils;
+  constexpr size_t pklen = utils::get_sphincs_pkey_len<n>();
+  constexpr size_t sklen = utils::get_sphincs_skey_len<n>();
+
+  uint8_t* pkey = static_cast<uint8_t*>(std::malloc(pklen));
+  uint8_t* skey = static_cast<uint8_t*>(std::malloc(sklen));
+
+  for (auto _ : state) {
+    sphincs::keygen<n, h, d, w, v>(skey, pkey);
+
+    benchmark::DoNotOptimize(skey);
+    benchmark::DoNotOptimize(pkey);
+    benchmark::ClobberMemory();
+  }
+
+  std::free(pkey);
+  std::free(skey);
+}
+
+}


### PR DESCRIPTION
Benchmark SPHINCS+ keygen, sign and verify routines, for various parameter sets, using `google-benchmark`.

---

Benchmark results on **Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz**, issue

```bash
make benchmark
```

```bash
2022-11-24T17:56:30+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 1.68, 2.21, 2.23
------------------------------------------------------------------------------------------------------------------------
Benchmark                                                              Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------------
bench_sphincs::keygen<16, 63, 7, 16, variant::robust>          223865189 ns    223551667 ns            3 items_per_second=4.47324/s
bench_sphincs::sign<16, 63, 7, 12, 14, 16, variant::robust>   1673343333 ns   1672366000 ns            1 items_per_second=0.597955/s
bench_sphincs::verify<16, 63, 7, 12, 14, 16, variant::robust>    1624058 ns      1622867 ns          383 items_per_second=616.194/s
bench_sphincs::keygen<16, 63, 7, 16, variant::simple>          114910381 ns    114836000 ns            6 items_per_second=8.70807/s
bench_sphincs::sign<16, 63, 7, 12, 14, 16, variant::simple>    870889893 ns    870356000 ns            1 items_per_second=1.14896/s
bench_sphincs::verify<16, 63, 7, 12, 14, 16, variant::simple>     919948 ns       889686 ns          821 items_per_second=1.12399k/s
bench_sphincs::keygen<16, 66, 22, 16, variant::robust>           3519567 ns      3517101 ns          199 items_per_second=284.325/s
bench_sphincs::sign<16, 66, 22, 6, 33, 16, variant::robust>     83328184 ns     83158375 ns            8 items_per_second=12.0252/s
bench_sphincs::verify<16, 66, 22, 6, 33, 16, variant::robust>    5011455 ns      5010190 ns          100 items_per_second=199.593/s
bench_sphincs::keygen<16, 66, 22, 16, variant::simple>           1838696 ns      1837453 ns          375 items_per_second=544.232/s
bench_sphincs::sign<16, 66, 22, 6, 33, 16, variant::simple>     42009972 ns     41976941 ns           17 items_per_second=23.8226/s
bench_sphincs::verify<16, 66, 22, 6, 33, 16, variant::simple>    2530698 ns      2529193 ns          274 items_per_second=395.383/s
bench_sphincs::keygen<24, 63, 7, 16, variant::robust>          322501013 ns    322310000 ns            2 items_per_second=3.1026/s
bench_sphincs::sign<24, 63, 7, 14, 17, 16, variant::robust>   2932460616 ns   2930447000 ns            1 items_per_second=0.341245/s
bench_sphincs::verify<24, 63, 7, 14, 17, 16, variant::robust>    2655033 ns      2653484 ns          275 items_per_second=376.863/s
bench_sphincs::keygen<24, 63, 7, 16, variant::simple>          167973781 ns    167865500 ns            4 items_per_second=5.95715/s
bench_sphincs::sign<24, 63, 7, 14, 17, 16, variant::simple>   1515394867 ns   1514429000 ns            1 items_per_second=0.660315/s
bench_sphincs::verify<24, 63, 7, 14, 17, 16, variant::simple>    1335074 ns      1334090 ns          543 items_per_second=749.574/s
bench_sphincs::keygen<24, 66, 22, 16, variant::robust>           5171228 ns      5166667 ns          135 items_per_second=193.548/s
bench_sphincs::sign<24, 66, 22, 8, 33, 16, variant::robust>    131464221 ns    131349800 ns            5 items_per_second=7.61326/s
bench_sphincs::verify<24, 66, 22, 8, 33, 16, variant::robust>    7344868 ns      7336526 ns           97 items_per_second=136.304/s
bench_sphincs::keygen<24, 66, 22, 16, variant::simple>           2718596 ns      2715891 ns          257 items_per_second=368.203/s
bench_sphincs::sign<24, 66, 22, 8, 33, 16, variant::simple>     68116879 ns     68079900 ns           10 items_per_second=14.6886/s
bench_sphincs::verify<24, 66, 22, 8, 33, 16, variant::simple>    3708584 ns      3705747 ns          190 items_per_second=269.851/s
bench_sphincs::keygen<32, 64, 8, 16, variant::robust>          214403107 ns    214250333 ns            3 items_per_second=4.66744/s
bench_sphincs::sign<32, 64, 8, 14, 22, 16, variant::robust>   2655703720 ns   2618478000 ns            1 items_per_second=0.381901/s
bench_sphincs::verify<32, 64, 8, 14, 22, 16, variant::robust>    3749786 ns      3747871 ns          186 items_per_second=266.818/s
bench_sphincs::keygen<32, 64, 8, 16, variant::simple>          110564633 ns    110483333 ns            6 items_per_second=9.05114/s
bench_sphincs::sign<32, 64, 8, 14, 22, 16, variant::simple>   1322491828 ns   1321609000 ns            1 items_per_second=0.756653/s
bench_sphincs::verify<32, 64, 8, 14, 22, 16, variant::simple>    1845741 ns      1843675 ns          326 items_per_second=542.395/s
bench_sphincs::keygen<32, 68, 17, 16, variant::robust>          14471887 ns     13960647 ns           51 items_per_second=71.6299/s
bench_sphincs::sign<32, 68, 17, 9, 35, 16, variant::robust>    272581306 ns    272364333 ns            3 items_per_second=3.67155/s
bench_sphincs::verify<32, 68, 17, 9, 35, 16, variant::robust>    7987809 ns      7970346 ns           81 items_per_second=125.465/s
bench_sphincs::keygen<32, 68, 17, 16, variant::simple>           7482949 ns      7231433 ns           97 items_per_second=138.285/s
bench_sphincs::sign<32, 68, 17, 9, 35, 16, variant::simple>    139193350 ns    139062200 ns            5 items_per_second=7.19103/s
bench_sphincs::verify<32, 68, 17, 9, 35, 16, variant::simple>    3758632 ns      3755781 ns          187 items_per_second=266.256/s
```