### PR TITLE
Add `dudect` -based Timing Leakage Detection Tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "gtest-parallel"]
 	path = gtest-parallel
 	url = https://github.com/google/gtest-parallel.git
+[submodule "dudect"]
+	path = dudect
+	url = https://github.com/oreparaz/dudect.git

--- a/Makefile
+++ b/Makefile
@@ -7,20 +7,26 @@ ASAN_FLAGS = -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsaniti
 UBSAN_FLAGS = -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=undefined # From https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
 
 SHA3_INC_DIR = ./sha3/include
+DUDECT_INC_DIR = ./dudect/src
 I_FLAGS = -I ./include
 DEP_IFLAGS = -I $(SHA3_INC_DIR)
+DUDECT_DEP_IFLAGS = $(DEP_IFLAGS) -I $(DUDECT_INC_DIR)
 
 SRC_DIR = include
 SPHINCS+_SOURCES := $(wildcard $(SRC_DIR)/*.hpp)
 BUILD_DIR = build
 ASAN_BUILD_DIR = $(BUILD_DIR)/asan
 UBSAN_BUILD_DIR = $(BUILD_DIR)/ubsan
+DUDECT_BUILD_DIR = $(BUILD_DIR)/dudect
 
 TEST_DIR = tests
+DUDECT_TEST_DIR = $(TEST_DIR)/dudect
 TEST_SOURCES := $(wildcard $(TEST_DIR)/*.cpp)
 TEST_OBJECTS := $(addprefix $(BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
 ASAN_TEST_OBJECTS := $(addprefix $(ASAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
 UBSAN_TEST_OBJECTS := $(addprefix $(UBSAN_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.o,$(TEST_SOURCES))))
+DUDECT_TEST_SOURCES := $(wildcard $(DUDECT_TEST_DIR)/*.cpp)
+DUDECT_TEST_BINARIES := $(addprefix $(DUDECT_BUILD_DIR)/, $(notdir $(patsubst %.cpp,%.out,$(DUDECT_TEST_SOURCES))))
 TEST_LINK_FLAGS = -lgtest -lgtest_main
 TEST_BINARY = $(BUILD_DIR)/test.out
 ASAN_TEST_BINARY = $(ASAN_BUILD_DIR)/test.out
@@ -48,10 +54,16 @@ $(ASAN_BUILD_DIR): $(BUILD_DIR)
 $(UBSAN_BUILD_DIR): $(BUILD_DIR)
 	mkdir -p $@
 
+$(DUDECT_BUILD_DIR): $(BUILD_DIR)
+	mkdir -p $@
+
 $(SHA3_INC_DIR):
 	git submodule update --init
 
 $(GTEST_PARALLEL): $(SHA3_INC_DIR)
+	git submodule update --init
+
+$(DUDECT_INC_DIR): $(GTEST_PARALLEL)
 	git submodule update --init
 
 $(BUILD_DIR)/%.o: $(TEST_DIR)/%.cpp $(BUILD_DIR) $(SHA3_INC_DIR)
@@ -72,6 +84,9 @@ $(ASAN_TEST_BINARY): $(ASAN_TEST_OBJECTS)
 $(UBSAN_TEST_BINARY): $(UBSAN_TEST_OBJECTS)
 	$(CXX) $(UBSAN_FLAGS) $^ $(TEST_LINK_FLAGS) -o $@
 
+$(DUDECT_BUILD_DIR)/%.out: $(DUDECT_TEST_DIR)/%.cpp $(DUDECT_BUILD_DIR) $(SHA3_INC_DIR) $(DUDECT_INC_DIR)
+	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(OPT_FLAGS) $(I_FLAGS) $(DUDECT_DEP_IFLAGS) -lm $(LINK_FLAGS) $< -o $@
+
 test: $(TEST_BINARY) $(GTEST_PARALLEL)
 	$(GTEST_PARALLEL) $< --print_test_times
 
@@ -80,6 +95,8 @@ asan_test: $(ASAN_TEST_BINARY) $(GTEST_PARALLEL)
 
 ubsan_test: $(UBSAN_TEST_BINARY) $(GTEST_PARALLEL)
 	$(GTEST_PARALLEL) $< --print_test_times
+
+dudect_test_build: $(DUDECT_TEST_BINARIES)
 
 $(BUILD_DIR)/%.o: $(BENCHMARK_DIR)/%.cpp $(BUILD_DIR) $(SHA3_INC_DIR)
 	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(OPT_FLAGS) $(I_FLAGS) $(DEP_IFLAGS) -c $< -o $@
@@ -103,5 +120,5 @@ perf: $(PERF_BINARY)
 clean:
 	rm -rf $(BUILD_DIR)
 
-format: $(SPHINCS+_SOURCES) $(TEST_SOURCES) $(BENCHMARK_SOURCES) $(BENCHMARK_HEADERS)
+format: $(SPHINCS+_SOURCES) $(TEST_SOURCES) $(DUDECT_TEST_SOURCES) $(BENCHMARK_SOURCES) $(BENCHMARK_HEADERS)
 	clang-format -i $^

--- a/tests/dudect/test_sphincs+_128f_simple_keygen.cpp
+++ b/tests/dudect/test_sphincs+_128f_simple_keygen.cpp
@@ -1,0 +1,78 @@
+#include "sphincs+_128f_simple.hpp"
+#include <cstdio>
+
+#define DUDECT_IMPLEMENTATION
+#define DUDECT_VISIBLITY_STATIC
+#include "dudect.h"
+
+uint8_t
+do_one_computation(uint8_t* const data)
+{
+  constexpr size_t doff0 = 0;
+  constexpr size_t doff1 = doff0 + sphincs_plus_128f_simple::n;
+  constexpr size_t doff2 = doff1 + sphincs_plus_128f_simple::n;
+  constexpr size_t doff3 = doff2 + sphincs_plus_128f_simple::n;
+
+  auto sk_seed = std::span<const uint8_t, doff1 - doff0>(data + doff0, doff1 - doff0);
+  auto sk_prf = std::span<const uint8_t, doff2 - doff1>(data + doff1, doff2 - doff1);
+  auto pk_seed = std::span<const uint8_t, doff3 - doff2>(data + doff2, doff3 - doff2);
+
+  std::array<uint8_t, sphincs_plus_128f_simple::SecKeyLen> skey{};
+  std::array<uint8_t, sphincs_plus_128f_simple::PubKeyLen> pkey{};
+
+  uint8_t ret_val = 0;
+
+  sphincs_plus_128f_simple::keygen(sk_seed, sk_prf, pk_seed, skey, pkey);
+  ret_val ^= (skey[0] ^ skey[skey.size() - 1]) ^ (pkey[0] ^ pkey[pkey.size() - 1]);
+
+  return ret_val;
+}
+
+void
+prepare_inputs(dudect_config_t* const c, uint8_t* const input_data, uint8_t* const classes)
+{
+  randombytes(input_data, c->number_measurements * c->chunk_size);
+
+  for (size_t i = 0; i < c->number_measurements; i++) {
+    classes[i] = randombit();
+    if (classes[i] == 0) {
+      std::memset(input_data + i * c->chunk_size, 0x00, c->chunk_size);
+    }
+  }
+}
+
+dudect_state_t
+test_sphincs_plus_128f_simple_keygen()
+{
+  constexpr size_t chunk_size = sphincs_plus_128f_simple::n + // Secret Key Seed
+                                sphincs_plus_128f_simple::n + // Secret Key PRF
+                                sphincs_plus_128f_simple::n;  // Public Key Seed
+  constexpr size_t number_measurements = 1e5;
+
+  dudect_config_t config = {
+    chunk_size,
+    number_measurements,
+  };
+  dudect_ctx_t ctx;
+  dudect_init(&ctx, &config);
+
+  dudect_state_t state = DUDECT_NO_LEAKAGE_EVIDENCE_YET;
+  while (state == DUDECT_NO_LEAKAGE_EVIDENCE_YET) {
+    state = dudect_main(&ctx);
+  }
+
+  dudect_free(&ctx);
+
+  printf("Detected timing leakage in \"%s\", defined in file \"%s\"\n", __func__, __FILE_NAME__);
+  return state;
+}
+
+int
+main()
+{
+  if (test_sphincs_plus_128f_simple_keygen() != DUDECT_NO_LEAKAGE_EVIDENCE_YET) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/dudect/test_sphincs+_128f_simple_sign.cpp
+++ b/tests/dudect/test_sphincs+_128f_simple_sign.cpp
@@ -1,0 +1,95 @@
+#include "prng.hpp"
+#include "sphincs+_128f_simple.hpp"
+#include <cstdio>
+
+#define DUDECT_IMPLEMENTATION
+#define DUDECT_VISIBLITY_STATIC
+#include "dudect.h"
+
+constexpr size_t MSG_BYTE_LEN = 64;
+
+uint8_t
+do_one_computation(uint8_t* const data)
+{
+  constexpr size_t doff0 = 0;
+  constexpr size_t doff1 = doff0 + MSG_BYTE_LEN;
+  constexpr size_t doff2 = doff1 + sphincs_plus_128f_simple::SecKeyLen;
+  constexpr size_t doff3 = doff2 + sphincs_plus_128f_simple::n;
+
+  auto msg = std::span(data + doff0, doff1 - doff0);
+  auto skey = std::span<const uint8_t, doff2 - doff1>(data + doff1, doff2 - doff1);
+  auto rand_bytes = std::span<const uint8_t, doff3 - doff2>(data + doff2, doff3 - doff2);
+
+  std::array<uint8_t, sphincs_plus_128f_simple::SigLen> sig{};
+
+  uint8_t ret_val = 0;
+
+  sphincs_plus_128f_simple::sign<true>(msg, skey, rand_bytes, sig);
+  ret_val ^= sig[0] ^ sig[sig.size() - 1];
+
+  return ret_val;
+}
+
+void
+prepare_inputs(dudect_config_t* const c, uint8_t* const input_data, uint8_t* const classes)
+{
+  randombytes(input_data, c->number_measurements * c->chunk_size);
+
+  for (size_t i = 0; i < c->number_measurements; i++) {
+    classes[i] = randombit();
+    if (classes[i] == 0) {
+      const size_t chunk_off = i * c->chunk_size;
+      const size_t skey_begin = chunk_off + MSG_BYTE_LEN;
+
+      std::array<uint8_t, sphincs_plus_128f_simple::n> sk_seed{};
+      std::array<uint8_t, sphincs_plus_128f_simple::n> sk_prf{};
+      std::array<uint8_t, sphincs_plus_128f_simple::n> pk_seed{};
+      auto skey = std::span<uint8_t, sphincs_plus_128f_simple::SecKeyLen>(input_data + skey_begin, sphincs_plus_128f_simple::SecKeyLen);
+      std::array<uint8_t, sphincs_plus_128f_simple::PubKeyLen> pkey{};
+
+      prng::prng_t prng;
+
+      prng.read(sk_seed);
+      prng.read(sk_prf);
+      prng.read(pk_seed);
+
+      sphincs_plus_128f_simple::keygen(sk_seed, sk_prf, pk_seed, skey, pkey);
+    }
+  }
+}
+
+dudect_state_t
+test_sphincs_plus_128f_simple_sign()
+{
+  constexpr size_t chunk_size = MSG_BYTE_LEN +                        // Message to be signed
+                                sphincs_plus_128f_simple::SecKeyLen + // Secret key used for signing the message
+                                sphincs_plus_128f_simple::n;          // Random bytes used for randomized message signing
+  constexpr size_t number_measurements = 1e4;
+
+  dudect_config_t config = {
+    chunk_size,
+    number_measurements,
+  };
+  dudect_ctx_t ctx;
+  dudect_init(&ctx, &config);
+
+  dudect_state_t state = DUDECT_NO_LEAKAGE_EVIDENCE_YET;
+  while (state == DUDECT_NO_LEAKAGE_EVIDENCE_YET) {
+    state = dudect_main(&ctx);
+  }
+
+  dudect_free(&ctx);
+
+  printf("Detected timing leakage in \"%s\", defined in file \"%s\"\n", __func__, __FILE_NAME__);
+  return state;
+}
+
+int
+main()
+{
+  if (test_sphincs_plus_128f_simple_sign() != DUDECT_NO_LEAKAGE_EVIDENCE_YET) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add timing leakage detection tests for *sphincs+-128f-simple* key generation and signing algorithm.
